### PR TITLE
Add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mappum/hackrf-stream.git"
+  },
   "author": "",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
Adds the missing `repository` field, fixes:

```
npm WARN hackrf-stream@1.0.1 No repository field.
```

and makes it easier to find this GitHub repository from https://www.npmjs.com/package/hackrf-stream
